### PR TITLE
Fix: check_cigar_sequences

### DIFF
--- a/checkalign/checkalign.py
+++ b/checkalign/checkalign.py
@@ -319,7 +319,8 @@ def checkalign():
             if with_ground_truth:
                 if gt_scores[line_num] != score:
                     is_correct = False
-
+            
+            is_traceback_correct = True
             if len(elements) == 4:
                 pattern = elements[2]
                 text = elements[3]
@@ -344,7 +345,7 @@ def checkalign():
                     text    = txt_line.strip()[1:]
                 ok = check_cigar_sequences(score, ops, cigar_reps, pattern, text)
                 if not ok:
-                    is_correct = False
+                    is_traceback_correct = False
                     #if not args.quiet:
                     #    error_console.print(f"CIGAR {line_num} do not fit the pattern and text.")
 
@@ -359,7 +360,7 @@ def checkalign():
                 error_console.print(f"Invalid distance function {args.distance_function}")
                 quit
 
-            if not is_correct:
+            if not is_correct or not is_traceback_correct:
                 update_incorrect_cigars_table(incorrect_cigars_table, line_num, score, cigar, cigar_score, gt_scores[line_num] if with_ground_truth else None)
                 #if not args.quiet:
                 #    get_incorrect_cigar_table(line_num, score, cigar, cigar_score, gt_scores[line_num] if with_ground_truth else None)


### PR DESCRIPTION
Previously, when the “-s” flag was used, the program did not correctly verify the result because it was overwritten by the score check. This commit fixes that issue: if the CIGAR string is incorrect (i.e., the pattern is not correctly transformed into the text according to the CIGAR) it is now properly counted as an incorrect result. 